### PR TITLE
-8: Use XOR for parity, check parity on render

### DIFF
--- a/4.min.html
+++ b/4.min.html
@@ -1,1 +1,1 @@
-<canvas id=a onclick=for(s=n,n=[i=3e3];i--;)for(jof[-50,-1,1,g=50])g+=s[i+j]|0,n[i]=g%2;d(a.height=250)><svg onload='n=[d=_=>n.map((b,i)=>a.getContext`2d`.fillRect(i%50*5,5*(i/50|0),b*5,5))];d(n[975]=1)'>
+<canvas id=a onclick=for(s=n,n=[i=3e3];i--;)for(jof[-50,-1,1,50])n[i]^=s[i+j];d(a.height=250)><svg onload='n=[d=_=>n.map((b,i)=>a.getContext`2d`.fillRect(i%50*5,5*(i/50|0),b%2*5,5))];d(n[975]=1)'>


### PR DESCRIPTION
Looks like we doesn't really care about anything except the least significant bit. Using `^` will change the LSB just as the normal `+`. AND it coerces the value to Int32.